### PR TITLE
Fix YouTube URL param handling in parseVideoUrl

### DIFF
--- a/src/Helpers/VideoHelper.php
+++ b/src/Helpers/VideoHelper.php
@@ -23,8 +23,8 @@ class VideoHelper
         }
 
         try {
-            if (preg_match(self::YOUTUBE_URL_PATTERN, $url, $matches, PREG_OFFSET_CAPTURE) > 0) {
-                $videoId = $matches[3][0] ?: throw new UnparseableVideoIdException();
+            if (preg_match(self::YOUTUBE_URL_PATTERN, $url) > 0) {
+                $videoId = self::parseYouTubeId($url) ?: throw new UnparseableVideoIdException();
                 $result = [
                     'provider' => 'youtube',
                     'videoId' => $videoId,
@@ -52,10 +52,6 @@ class VideoHelper
             } else {
                 throw new UnknownVideoProviderException();
             }
-
-            if (strpos($result['videoId'], '&')) {
-                $result['videoId'] = substr($result['videoId'], 0, strpos($result['videoId'], '&'));
-            }
         } catch (UnknownVideoProviderException|UnparseableVideoIdException $e) {
             if (App::devMode()) {
                 throw $e;
@@ -64,6 +60,22 @@ class VideoHelper
         }
 
         return $result;
+    }
+
+    /**
+     * Extract the video ID from a YouTube URL, ignoring any query params.
+     *
+     * Handles the `youtube.com/watch?v=ID` form (ID lives in the `v` query
+     * param) as well as the path-based forms `youtu.be/ID`, `embed/ID` and
+     * `shorts/ID`, where the ID is the last path segment. Tracking params such
+     * as the `?si=` on youtu.be share links are ignored.
+     */
+    private static function parseYouTubeId(string $url): string
+    {
+        $parts = parse_url($url);
+        parse_str($parts['query'] ?? '', $params);
+
+        return $params['v'] ?? basename($parts['path'] ?? '');
     }
 
     private static function ytThumbUrl(string $id, string $size = 'maxresdefault'): string

--- a/tests/Unit/StringHelperTest.php
+++ b/tests/Unit/StringHelperTest.php
@@ -46,6 +46,31 @@ describe('VideoHelper', function() {
                 expect($this->result['thumbnail']['md'])->toBe('https://img.youtube.com/vi/9bZkp7q19f0/mqdefault.jpg');
                 expect($this->result['thumbnail']['sm'])->toBe('https://img.youtube.com/vi/9bZkp7q19f0/sddefault.jpg');
             });
+
+            it('strips extra params from a youtube.com watch URL', function() {
+                $result = VideoHelper::parseVideoUrl('https://www.youtube.com/watch?v=9bZkp7q19f0&feature=youtu.be');
+                expect($result['videoId'])->toBe('9bZkp7q19f0');
+            });
+
+            it('strips the si tracking param from a youtu.be share URL', function() {
+                $result = VideoHelper::parseVideoUrl('https://youtu.be/9bZkp7q19f0?si=aBcDeFgHiJkLmNoP');
+                expect($result['videoId'])->toBe('9bZkp7q19f0');
+            });
+
+            it('extracts the video ID from a bare youtu.be URL', function() {
+                $result = VideoHelper::parseVideoUrl('https://youtu.be/9bZkp7q19f0');
+                expect($result['videoId'])->toBe('9bZkp7q19f0');
+            });
+
+            it('extracts the video ID from an embed URL', function() {
+                $result = VideoHelper::parseVideoUrl('https://www.youtube.com/embed/9bZkp7q19f0');
+                expect($result['videoId'])->toBe('9bZkp7q19f0');
+            });
+
+            it('extracts the video ID from a shorts URL', function() {
+                $result = VideoHelper::parseVideoUrl('https://www.youtube.com/shorts/9bZkp7q19f0');
+                expect($result['videoId'])->toBe('9bZkp7q19f0');
+            });
         });
 
         describe('Vimeo Support', function() {


### PR DESCRIPTION
## Problem

`youtu.be` share links carry a `?si=` tracking param that leaked into the parsed video ID, breaking thumbnail URLs. The old cleanup only stripped params starting with `&`, not `?`.

Fixes #92.

## Change

Replaces the ad-hoc `&` stripping with a `parseYouTubeId()` helper that uses native `parse_url()` + `parse_str()`:

- `youtube.com/watch?v=ID` → reads the `v` query param
- `youtu.be/ID`, `embed/ID`, `shorts/ID` → takes the last path segment via `basename()`
- Any query params (`?si=`, `&feature=`, `&t=`) are ignored rather than stripped after the fact

## Tests

Added cases for `?si=` share links, `&feature=` watch links, bare `youtu.be`, `embed`, and `shorts` URLs. All 42 tests pass; ECS and PHPStan clean.