### PR TITLE
Pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,20 +10,20 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
     - name: Install dependencies
-      uses: php-actions/composer@v6
+      uses: php-actions/composer@8a65f0d3c6a1d17ca4800491a40b5756a4c164f3 # v6
       with:
         php_version: latest
         args: --profile --ignore-platform-reqs
     - name: Run phpstan
-      uses: php-actions/phpstan@v3
+      uses: php-actions/phpstan@d8f8887acaac249b05ac11909c4cdbb018f52211 # v3
       with:
         php_version: latest
         memory_limit: 1G
     - name: Run Check ECS
-      uses: php-actions/composer@v6
+      uses: php-actions/composer@8a65f0d3c6a1d17ca4800491a40b5756a4c164f3 # v6
       with:
         command: run-script check-cs
         php_version: latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,8 +12,8 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 18
           cache: npm
@@ -23,7 +23,7 @@ jobs:
         run: npm run docs:build
 
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: docs/.vitepress/dist

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -13,18 +13,18 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: main
 
       - name: Update Changelog
-        uses: stefanzweifel/changelog-updater-action@v1
+        uses: stefanzweifel/changelog-updater-action@a938690fad7edf25368f37e43a1ed1b34303eb36 # v1
         with:
           latest-version: ${{ github.event.release.name }}
           release-notes: ${{ github.event.release.body }}
 
       - name: Commit updated CHANGELOG
-        uses: stefanzweifel/git-auto-commit-action@v7
+        uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d # v7
         with:
           branch: main
           commit_message: Update CHANGELOG


### PR DESCRIPTION
Pinned GH action SHAs as follows:

| Action | Pinned SHA (was) |
|---|---|
| actions/checkout | df4cb1c… (v6) |
| actions/setup-node | 48b55a0… (v6) |
| peaceiris/actions-gh-pages | 84c30a8… (v4) |
| stefanzweifel/changelog-updater-action | a938690… (v1) |
| stefanzweifel/git-auto-commit-action | 4a55954… (v7) |
| php-actions/composer | 8a65f0d… (v6) |
| php-actions/phpstan | d8f8887… (v3) |

The org requires all actions pinned to a full commit SHA, which was blocking CI.